### PR TITLE
Fixing use depreciated method getargspec

### DIFF
--- a/jsonformatter/jsonformatter.py
+++ b/jsonformatter/jsonformatter.py
@@ -188,7 +188,7 @@ class JsonFormatter(logging.Formatter):
 
                     if inspect.isfunction(func):
                         argspec = getattr(inspect, 'getfullargspec',
-                                          inspect.getargspec)(func)
+                                          inspect.signature)(func)
                         if argspec.args:
                             raise TypeError(
                                 "`%s` must no Positional Parameters." % func.__name__


### PR DESCRIPTION
Fixing the use depreciated method getargspec and replacing it with signature method to make the code compatible with python version 3.11.0