### PR TITLE
Add option to build wheel

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -49,5 +49,6 @@ setup(
     author_email='my_colorful_days@163.com',
     url='https://github.com/MyColorfulDays/jsonformatter.git',
     license='BSD License',
-    packages=['jsonformatter']
+    packages=['jsonformatter'],
+    options={'bdist_wheel': {'universal': True}},
 )


### PR DESCRIPTION
Just checked that jsonformatter doesn't have a wheel on PyPI, is there a reason for that? A universal wheel should be fine if it's just pure python that isn't platform dependent.